### PR TITLE
Only query for runs for the specified branch

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -101,7 +101,7 @@ api() {
     echo >&2 "api failed:"
     echo >&2 "path: $path"
     echo >&2 "response: $response"
-    if [[ "$response" == *'"Server Error"'* ]]; then 
+    if [[ "$response" == *'"Server Error"'* ]]; then
       echo "Server error - trying again"
     else
       exit 1
@@ -118,8 +118,9 @@ lets_wait() {
 # Return the ids of the most recent workflow runs, optionally filtered by user
 get_workflow_runs() {
   since=${1:?}
+  ref=${2:?}
 
-  query="event=workflow_dispatch&created=>=$since${INPUT_GITHUB_USER+&actor=}${INPUT_GITHUB_USER}&per_page=100"
+  query="event=workflow_dispatch&created=>=$since&branch=${ref}${INPUT_GITHUB_USER+&actor=}${INPUT_GITHUB_USER}&per_page=100"
 
   echo "Getting workflow runs using query: ${query}" >&2
 
@@ -132,7 +133,7 @@ trigger_workflow() {
   START_TIME=$(date +%s)
   SINCE=$(date -u -Iseconds -d "@$((START_TIME - 120))") # Two minutes ago, to overcome clock skew
 
-  OLD_RUNS=$(get_workflow_runs "$SINCE")
+  OLD_RUNS=$(get_workflow_runs "$SINCE" "$ref")
 
   echo >&2 "Triggering workflow:"
   echo >&2 "  workflows/${INPUT_WORKFLOW_FILE_NAME}/dispatches"
@@ -145,7 +146,7 @@ trigger_workflow() {
   while [ "$NEW_RUNS" = "$OLD_RUNS" ]
   do
     lets_wait
-    NEW_RUNS=$(get_workflow_runs "$SINCE")
+    NEW_RUNS=$(get_workflow_runs "$SINCE" "$ref")
   done
 
   # Return new run ids


### PR DESCRIPTION
When we have two branches active in https://github.com/rapidsai/workflows, sometimes `trigger-workflow-and-wait` will get both run ids and wait for both. This is problematic if one fails thus preventing a trigger for the downstream tests.

The [API to query for runs](https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-workflow) can take a branch argument and we always supply the branch as for the `ref` input.

I don't know if this can be upstreamed, but I think it will work for RAPIDS for now.

I'm not 100% sure how to test, but grabbing the query from https://github.com/rapidsai/workflows/actions/runs/9185613915/job/25259892341#step:3:26 and adding the `branch` param like https://api.github.com/repos/rapidsai/rmm/actions/workflows/build.yaml/runs?event=workflow_dispatch&created=%3E=2024-05-22T05:01:27+00:00&branch=branch-24.08&actor=GPUtester&per_page=100 works.