### PR TITLE
Discard dispatch API response body

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -101,7 +101,7 @@ api() {
     echo >&2 "api failed:"
     echo >&2 "path: $path"
     echo >&2 "response: $response"
-    if [[ "$response" == *'"Server Error"'* ]]; then 
+    if [[ "$response" == *'"Server Error"'* ]]; then
       echo "Server error - trying again"
     else
       exit 1
@@ -139,7 +139,7 @@ trigger_workflow() {
   echo >&2 "  {\"ref\":\"${ref}\",\"inputs\":${client_payload}}"
 
   api "workflows/${INPUT_WORKFLOW_FILE_NAME}/dispatches" \
-    --data "{\"ref\":\"${ref}\",\"inputs\":${client_payload}}"
+    --data "{\"ref\":\"${ref}\",\"inputs\":${client_payload}}" > /dev/null
 
   NEW_RUNS=$OLD_RUNS
   while [ "$NEW_RUNS" = "$OLD_RUNS" ]


### PR DESCRIPTION
Backporting https://github.com/convictional/trigger-workflow-and-wait/pull/109 to our fork.

Resolves issues discussed in https://github.com/orgs/community/discussions/9752#discussioncomment-15294117.

That discussion mentions the API break will be rolled back but GitHub may still make this change in January 2026. This change should make our action work either way, in my understanding.
